### PR TITLE
Fix "follow logs" behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Types of changes are:
 * **Fixed** for any bug fixes.
 
 ## [Unreleased]
-
+### Fixed
+* Omitting the `--end` option now correctly follows logs until interrupted
 
 ## [0.2.0] - 2022-08-09
 ### Added

--- a/elastic_log_cli/cli.py
+++ b/elastic_log_cli/cli.py
@@ -95,6 +95,7 @@ def cli(
         size=page_size,
         source=source,
         backoff=exponential_backoff(on_backoff=_log_backoff),
+        follow=not end,
     ):
         print(json.dumps(doc["_source"], sort_keys=True))
 

--- a/elastic_log_cli/search.py
+++ b/elastic_log_cli/search.py
@@ -23,6 +23,7 @@ def search_after_scan(
     source: list[str] = None,
     size: int = 1000,
     backoff: Backoff = None,
+    follow: bool = False,
 ) -> Iterator[dict]:
     """Implementation of `search_after` pagination (without point-in-time).
 
@@ -50,9 +51,12 @@ def search_after_scan(
                 search_after=search_after,
             )
             hits = result["hits"]["hits"]
-            if not hits:
+            if not hits and not follow:
                 return
-            search_after = hits[-1]["sort"]
+            try:
+                search_after = hits[-1]["sort"]
+            except IndexError:
+                pass
             for hit in hits:
                 yield hit
 


### PR DESCRIPTION
Any related Github Issues?: _add link here_ 

### Fixed
* Omitting the `--end` option now correctly follows logs until interrupted

# Check list

## Before asking for a review

- [x] Target branch is `master`
- [x] [`[Unreleased]`](../blob/master/CHANGELOG.md#unreleased) section in [CHANGELOG.md](../blob/master/CHANGELOG.md) is updated.
- [x] I reviewed the "Files changed" tab and self-annotated anything unexpected.

## Before review (reviewer)

- [x] All of the above are checked and true. **Review ALL items.** If not, return the PR to the author.
- [x] Continuous Integration is passing. If not, return the PR to the author.

## After merge (reviewer)

- [x] Any issues that may now be closed are closed.
